### PR TITLE
grid8

### DIFF
--- a/app/components/TextAnimation.tsx
+++ b/app/components/TextAnimation.tsx
@@ -392,6 +392,8 @@ const NeuralNetwork: React.FC<BackgroundEffectProps> = ({
 const GeometricWaves: React.FC<BackgroundEffectProps> = ({ 
   intensity = 1, 
   color = '#ff6b6b',
+  // This secondary color can be customized when using the GeometricWaves component:
+  // Example: <GeometricWaves secondaryColor="#ff0000" />
   secondaryColor = '#4ecdc4'
 }) => {
   const meshRef = useRef<THREE.InstancedMesh>(null);
@@ -424,7 +426,12 @@ const GeometricWaves: React.FC<BackgroundEffectProps> = ({
   return (
     <instancedMesh ref={meshRef} args={[undefined, undefined, count]}>
       <octahedronGeometry args={[0.2]} />
-      <meshPhongMaterial color={color} transparent opacity={0.7} />
+      <meshPhongMaterial 
+        color={color as THREE.ColorRepresentation} 
+        // Remove secondaryColor as it's not a valid property of MeshPhongMaterial
+        transparent 
+        opacity={0.7} 
+      />
     </instancedMesh>
   );
 };
@@ -493,6 +500,7 @@ const ParticleFlow: React.FC<BackgroundEffectProps> = ({
       </bufferGeometry>
       <pointsMaterial
         color={color}
+       
         size={0.05}
         transparent
         opacity={0.6}

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -93,7 +93,7 @@ export default function Index() {
           }}>
            <TextAnimation 
   text="Frontend" 
-  effect="waves"
+  backgroundEffect="waves"
   backgroundIntensity={1.2}
   primaryColor="#ff6b6b"
   secondaryColor="#4ecdc4"


### PR DESCRIPTION
- **orbit-sprites**
- **nav-cubes**
- **ball-basics**
- **wall-height**
- **mobile-tilt**
- **front-end-css**
- **threeCss**
- **drei-version**
- **drei-version2**
- **physics**
- **physics2**
- **walls**
- **walls**
- **walls3**
- **raycaster-update**
- **3d-nav**
- **3d-grid**
- **3d-grid2**
- **3d-grid3**
- **tooltips**
- **neon-cube**
- **text-opt**
- **text-opt2**
- **text**
- **text-anim**
- **DEP**
- **pjson**
- **text**
- **text2**
- **curve**
- **curve2**
- **curve3**
- **curve4**
- **curve-less-more-readable**
- **curve-less-more-readable2**
- **curve-less-more-readable3**
- **bigger**
- **funnner**
- **grid1**
- **links**
- **grid-style**
- **text**
- **cooler-effects**
- **cooler-grid**
- **better-card-type-issues**
- **better-waves**
- **better-waves2**
