### PR TITLE
grid11

### DIFF
--- a/app/components/TextAnimation.tsx
+++ b/app/components/TextAnimation.tsx
@@ -520,10 +520,10 @@ const NeuralNetwork: React.FC<BackgroundEffectProps> = ({
 // Geometric Waves Effect
 const GeometricWaves: React.FC<BackgroundEffectProps> = ({ 
   intensity = 1, 
-  color = '#ffffff',
+  color = "#00FF00",
   // This secondary color can be customized when using the GeometricWaves component:
   // Example: <GeometricWaves secondaryColor="#ff0000" />
-  secondaryColor = '#4ecdc4'
+  secondaryColor = "#FF69B4"
 }) => {
   const meshRef = useRef<THREE.InstancedMesh>(null);
   const { viewport } = useThree();

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -93,10 +93,10 @@ export default function Index() {
           }}>
            <TextAnimation 
   text="Frontend" 
-  backgroundEffect="waves"
+  backgroundEffect="particles"
   backgroundIntensity={1.2}
-  primaryColor="#800080"
-  secondaryColor="#4ecdc4"
+  primaryColor="#FF69B4"
+  secondaryColor="#FF69B4"
 />
           </a>
           <a href="/threejs" style={{


### PR DESCRIPTION
- **orbit-sprites**
- **nav-cubes**
- **ball-basics**
- **wall-height**
- **mobile-tilt**
- **front-end-css**
- **threeCss**
- **drei-version**
- **drei-version2**
- **physics**
- **physics2**
- **walls**
- **walls**
- **walls3**
- **raycaster-update**
- **3d-nav**
- **3d-grid**
- **3d-grid2**
- **3d-grid3**
- **tooltips**
- **neon-cube**
- **text-opt**
- **text-opt2**
- **text**
- **text-anim**
- **DEP**
- **pjson**
- **text**
- **text2**
- **curve**
- **curve2**
- **curve3**
- **curve4**
- **curve-less-more-readable**
- **curve-less-more-readable2**
- **curve-less-more-readable3**
- **bigger**
- **funnner**
- **grid1**
- **links**
- **grid-style**
- **text**
- **cooler-effects**
- **cooler-grid**
- **better-card-type-issues**
- **better-waves**
- **better-waves2**
- **better-waves3**
- **frontend**
- **navbar**
- **navbar**
